### PR TITLE
Added `endpoint_url` to opener and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ same way as any other supported filesystem.
 Open an S3FS by explicitly using the constructor:
 
 ```python
-from s3_s3fs import s3FS
+from fs_s3fs import S3FS
 s3fs = S3FS('mybucket')
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,21 @@ same way as any other supported filesystem.
 
 Open an S3FS by explicitly using the constructor:
 
-```python
-from fs_s3fs import S3FS
-s3fs = S3FS('mybucket')
-```
-
-Or with a FS URL:
-
-```python
-from fs import open_fs
-s3fs = open_fs('s3://mybucket')
-```
+ ```python
+  from s3_s3fs import s3FS
+  s3fs = S3FS('mybucket')
+  # to use an s3-compatible service
+  s3fs = S3FS('mybucket', endpoint_url='service.endpoint.url')
+  ```
+  
+  Or with a FS URL:
+  
+  ```python
+  from fs import open_fs
+  s3fs = open_fs('s3://mybucket')
+  # to use an s3-compatible service
+  s3fs = open_fs('s3://mybucket?endpoint_url=service.endpoint.url')
+  ```
 
 ## Downloading Files
 

--- a/README.rst
+++ b/README.rst
@@ -1,71 +1,77 @@
-# S3FS
+S3FS
+====
 
-S3FS is a [PyFilesystem](https://www.pyfilesystem.org/) interface to
+S3FS is a `PyFilesystem <https://www.pyfilesystem.org/>`__ interface to
 Amazon S3 cloud storage.
 
-As a PyFilesystem concrete class, [S3FS](http://fs-s3fs.readthedocs.io/en/latest/) allows you to work with S3 in the
-same way as any other supported filesystem.
+As a PyFilesystem concrete class,
+`S3FS <http://fs-s3fs.readthedocs.io/en/latest/>`__ allows you to work
+with S3 in the same way as any other supported filesystem.
 
-
-## Opening a S3FS
+Opening a S3FS
+--------------
 
 Open an S3FS by explicitly using the constructor:
 
- ```python
-  from s3_s3fs import s3FS
-  s3fs = S3FS('mybucket')
-  # to use an s3-compatible service
-  s3fs = S3FS('mybucket', endpoint_url='service.endpoint.url')
-  ```
-  
-  Or with a FS URL:
-  
-  ```python
-  from fs import open_fs
-  s3fs = open_fs('s3://mybucket')
-  # to use an s3-compatible service
-  s3fs = open_fs('s3://mybucket?endpoint_url=service.endpoint.url')
-  ```
+.. code:: python
 
-## Downloading Files
+    from s3_s3fs import s3FS
+    s3fs = S3FS('mybucket')
+    # to use an s3-compatible service
+    s3fs = S3FS('mybucket', endpoint_url='service.endpoint.url')
 
-To *download* files from an S3 bucket, open a file on the S3
-filesystem for reading, then write the data to a file on the local
-filesystem. Here's an example that copies a file `example.mov` from
-S3 to your HD:
+Or with a FS URL:
 
-```python
-from fs.tools import copy_file_data
-with s3fs.open('example.mov', 'rb') as remote_file:
-    with open('example.mov', 'wb') as local_file:
-        copy_file_data(remote_file, local_file)
-```
+.. code:: python
+
+    from fs import open_fs
+    s3fs = open_fs('s3://mybucket')
+    # to use an s3-compatible service
+    s3fs = open_fs('s3://mybucket?endpoint_url=service.endpoint.url')
+
+Downloading Files
+-----------------
+
+To *download* files from an S3 bucket, open a file on the S3 filesystem
+for reading, then write the data to a file on the local filesystem.
+Here's an example that copies a file ``example.mov`` from S3 to your HD:
+
+.. code:: python
+
+    from fs.tools import copy_file_data
+    with s3fs.open('example.mov', 'rb') as remote_file:
+        with open('example.mov', 'wb') as local_file:
+            copy_file_data(remote_file, local_file)
 
 Although it is preferable to use the higher-level functionality in the
-`fs.copy` module. Here's an example:
+``fs.copy`` module. Here's an example:
 
-```python
-from fs.copy import copy_file
-copy_file(s3fs, 'example.mov', './', 'example.mov')
-```
+.. code:: python
 
-## Uploading Files
+    from fs.copy import copy_file
+    copy_file(s3fs, 'example.mov', './', 'example.mov')
 
-You can *upload* files in the same way. Simply copy a file from a
-source filesystem to the S3 filesystem.
-See [Moving and Copying](https://docs.pyfilesystem.org/en/latest/guide.html#moving-and-copying)
+Uploading Files
+---------------
+
+You can *upload* files in the same way. Simply copy a file from a source
+filesystem to the S3 filesystem. See `Moving and
+Copying <https://docs.pyfilesystem.org/en/latest/guide.html#moving-and-copying>`__
 for more information.
 
-## S3 URLs
+S3 URLs
+-------
 
 You can get a public URL to a file on a S3 bucket as follows:
 
-```python
-movie_url = s3fs.geturl('example.mov')
-```
+.. code:: python
 
-## Documentation
+    movie_url = s3fs.geturl('example.mov')
 
-- [PyFilesystem Wiki](https://www.pyfilesystem.org)
-- [S3FS Reference](http://fs-s3fs.readthedocs.io/en/latest/)
-- [PyFilesystem Reference](https://docs.pyfilesystem.org/en/latest/reference/base.html)
+Documentation
+-------------
+
+-  `PyFilesystem Wiki <https://www.pyfilesystem.org>`__
+-  `S3FS Reference <http://fs-s3fs.readthedocs.io/en/latest/>`__
+-  `PyFilesystem
+   Reference <https://docs.pyfilesystem.org/en/latest/reference/base.html>`__

--- a/README.rst
+++ b/README.rst
@@ -1,73 +1,71 @@
-S3FS
-====
+# S3FS
 
-S3FS is a `PyFilesystem <https://www.pyfilesystem.org/>`__ interface to
+S3FS is a [PyFilesystem](https://www.pyfilesystem.org/) interface to
 Amazon S3 cloud storage.
 
-As a PyFilesystem concrete class,
-`S3FS <http://fs-s3fs.readthedocs.io/en/latest/>`__ allows you to work
-with S3 in the same way as any other supported filesystem.
+As a PyFilesystem concrete class, [S3FS](http://fs-s3fs.readthedocs.io/en/latest/) allows you to work with S3 in the
+same way as any other supported filesystem.
 
-Opening a S3FS
---------------
+
+## Opening a S3FS
 
 Open an S3FS by explicitly using the constructor:
 
-.. code:: python
+ ```python
+  from s3_s3fs import s3FS
+  s3fs = S3FS('mybucket')
+  # to use an s3-compatible service
+  s3fs = S3FS('mybucket', endpoint_url='service.endpoint.url')
+  ```
+  
+  Or with a FS URL:
+  
+  ```python
+  from fs import open_fs
+  s3fs = open_fs('s3://mybucket')
+  # to use an s3-compatible service
+  s3fs = open_fs('s3://mybucket?endpoint_url=service.endpoint.url')
+  ```
 
-    from s3_s3fs import s3FS
-    s3fs = S3FS('mybucket')
+## Downloading Files
 
-Or with a FS URL:
+To *download* files from an S3 bucket, open a file on the S3
+filesystem for reading, then write the data to a file on the local
+filesystem. Here's an example that copies a file `example.mov` from
+S3 to your HD:
 
-.. code:: python
-
-    from fs import open_fs
-    s3fs = open_fs('s3://mybucket')
-
-Downloading Files
------------------
-
-To *download* files from an S3 bucket, open a file on the S3 filesystem
-for reading, then write the data to a file on the local filesystem.
-Here's an example that copies a file ``example.mov`` from S3 to your HD:
-
-.. code:: python
-
-    from fs.tools import copy_file_data
-    with s3fs.open('example.mov', 'rb') as remote_file:
-        with open('example.mov', 'wb') as local_file:
-            copy_file_data(remote_file, local_file)
+```python
+from fs.tools import copy_file_data
+with s3fs.open('example.mov', 'rb') as remote_file:
+    with open('example.mov', 'wb') as local_file:
+        copy_file_data(remote_file, local_file)
+```
 
 Although it is preferable to use the higher-level functionality in the
-``fs.copy`` module. Here's an example:
+`fs.copy` module. Here's an example:
 
-.. code:: python
+```python
+from fs.copy import copy_file
+copy_file(s3fs, 'example.mov', './', 'example.mov')
+```
 
-    from fs.copy import copy_file
-    copy_file(s3fs, 'example.mov', './', 'example.mov')
+## Uploading Files
 
-Uploading Files
----------------
-
-You can *upload* files in the same way. Simply copy a file from a source
-filesystem to the S3 filesystem. See `Moving and
-Copying <https://docs.pyfilesystem.org/en/latest/guide.html#moving-and-copying>`__
+You can *upload* files in the same way. Simply copy a file from a
+source filesystem to the S3 filesystem.
+See [Moving and Copying](https://docs.pyfilesystem.org/en/latest/guide.html#moving-and-copying)
 for more information.
 
-S3 URLs
--------
+## S3 URLs
 
 You can get a public URL to a file on a S3 bucket as follows:
 
-.. code:: python
+```python
+movie_url = s3fs.geturl('example.mov')
+```
 
-    movie_url = s3fs.geturl('example.mov')
+## Documentation
 
-Documentation
--------------
-
--  `PyFilesystem Wiki <https://www.pyfilesystem.org>`__
--  `S3FS Reference <http://fs-s3fs.readthedocs.io/en/latest/>`__
--  `PyFilesystem
-   Reference <https://docs.pyfilesystem.org/en/latest/reference/base.html>`__
+- [PyFilesystem Wiki](https://www.pyfilesystem.org)
+- [S3FS Reference](http://fs-s3fs.readthedocs.io/en/latest/)
+- [PyFilesystem Reference](https://docs.pyfilesystem.org/en/latest/reference/base.html)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ and secret key configured on your system. You may also specify when
 creating the filesystem instance. Here's how you would do that with an
 opener::
 
-    s3fs = open_fs('s3://<access key>:<secret key>/mybucket')
+    s3fs = open_fs('s3://<access key>:<secret key>@mybucket')
 
 Here's how you specify credentials with the constructor::
 

--- a/fs_s3fs/opener.py
+++ b/fs_s3fs/opener.py
@@ -27,5 +27,6 @@ class S3FSOpener(Opener):
             dir_path=dir_path or '/',
             aws_access_key_id=parse_result.username or None,
             aws_secret_access_key=parse_result.password or None,
+            endpoint_url=parse_result.params.get('endpoint_url', None)
         )
         return s3fs


### PR DESCRIPTION
I fixed a couple of typos, added examples for using `endpoint_url`, and added a change to the `opener` to accept an `endpoint_url` URL parameter.