### PR TITLE
Remove strict dependency on boto3 1.4.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open('README.rst', 'rt') as f:
     DESCRIPTION = f.read()
 
 REQUIREMENTS = [
-    "boto3~=1.4.0",
+    "boto3>=1.4.0,<2.0.0",
     "fs~=2.0.12",
     "six~=1.10.0"
 ]


### PR DESCRIPTION
Hard coding the dependency blocks sibling modules using newer boto3 features from working.