### PR TITLE
Loosen constraint on six version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('README.rst', 'rt') as f:
 REQUIREMENTS = [
     "boto3~=1.4",
     "fs~=2.0.18",
-    "six~=1.10.0"
+    "six~=1.10"
 ]
 
 setup(


### PR DESCRIPTION
setup.py currently declares a dependency on "six~=1.10.0", which prevents use of the latest release (1.11.0).  It looks like this constraint was copied from the "fs" package, which [loosened this constraint](https://github.com/PyFilesystem/pyfilesystem2/commit/f8d2ce98352d2c199f499c1a2176f508ff69004a#diff-2eeaed663bd0d25b7e608891384b7298L29) six months ago.  This just brings the two packages back into sync.