### PR TITLE
Updated docs to include example on using `endpoint_url`.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,14 +29,26 @@ the GitHub repos at https://github.com/pyfilesystem/s3fs
 Opening an S3 Filesystem
 ========================
 
-There are two options for constructing a :ref:`s3fs` instance. The simplest way
-is with an *opener*, which is a simple URL like syntax. Here is an example::
+There are two options for constructing a :ref:`s3fs` instance.
+
+============
+Implicitly
+============
+
+The simplest way is with an *opener*, which is a simple URL like syntax. Here is an example::
 
     from fs import open_fs
-    s3fs = open_fs('s3://mybucket/')
+    s3fs = open_fs('s3://mybucket')
 
-For more granular control, you may import the S3FS class and construct
-it explicitly::
+If your S3 instance is hosted elsewhere you may need to pass in the url. Here is an example where <url> is the url of the S3 application::
+
+    s3fs = open_fs('s3://mybucket?endpoint_url=<url>')
+
+==========
+Explicitly
+==========
+
+For more granular control, you may import the S3FS class and construct it explicitly::
 
     from fs_s3fs import S3FS
     s3fs = S3FS('mybucket')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,14 +78,15 @@ and secret key configured on your system. You may also specify when
 creating the filesystem instance. Here's how you would do that with an
 opener::
 
-    s3fs = open_fs('s3://<access key>:<secret key>@mybucket')
+    s3fs = open_fs('s3://<access key>:<secret key>@mybucket?endpoint_url=<url>')
 
 Here's how you specify credentials with the constructor::
 
     s3fs = S3FS(
         'mybucket'
         aws_access_key_id=<access key>,
-        aws_secret_access_key=<secret key>
+        aws_secret_access_key=<secret key>,
+        endpoint_url=<url>
     )
 
 .. note::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,15 +78,14 @@ and secret key configured on your system. You may also specify when
 creating the filesystem instance. Here's how you would do that with an
 opener::
 
-    s3fs = open_fs('s3://<access key>:<secret key>@mybucket?endpoint_url=<url>')
+    s3fs = open_fs('s3://<access key>:<secret key>@mybucket')
 
 Here's how you specify credentials with the constructor::
 
     s3fs = S3FS(
         'mybucket'
         aws_access_key_id=<access key>,
-        aws_secret_access_key=<secret key>,
-        endpoint_url=<url>
+        aws_secret_access_key=<secret key>
     )
 
 .. note::


### PR DESCRIPTION
I wanted to open an s3 file system to an external url(minio). The docs didn't seem to have what I was looking for so I went searching through the code. Ends up all you need to do is add `?endpoint_url=<url>` to the string passed into `open_fs` from pyfilesystem. Figured I would update the docs to pay it forward.