### PR TITLE
Enable upload/download ExtraArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,19 @@ import fs, fs.mirror
 s3fs = S3FS('example', upload_args={"CacheControl": "max-age=2592000", "ACL": "public-read"})
 fs.mirror.mirror('/path/to/mirror', s3fs)
 ```
+
 see [the Boto3 docs](https://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS)
 for more information.
+
+`acl` and `cache_control` are exposed explicitly for convenience, and can be used in URLs.
+It is important to URL-Escape the `cache_control` value in a URL, as it may contain special characters.
+
+```python
+import fs, fs.mirror
+with open fs.open_fs('s3://example?acl=public-read&cache_control=max-age%3D2592000%2Cpublic') as s3fs
+    fs.mirror.mirror('/path/to/mirror', s3fs)
+```
+
 
 ## S3 URLs
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ source filesystem to the S3 filesystem.
 See [Moving and Copying](https://docs.pyfilesystem.org/en/latest/guide.html#moving-and-copying)
 for more information.
 
+## ExtraArgs
+
+S3 objects have additional properties, beyond a traditional
+filesystem. These options can be set using the `upload_args`
+and `download_args` properties. When set on an instantiated
+filesystem, they are handed to upload and download methods,
+as appropriate, for the lifetime of the filesystem instance.
+
+For example, to set the `cache-control` header of all objects
+uploaded to a bucket:
+
+```python
+import fs, fs.mirror
+with fs.open_fs('s3://bucket/') as bucket:
+    bucket.upload_args = {"CacheControl": "max-age=2592000", "ACL": "public-read"}
+    fs.mirror.mirror('/path/to/mirror', bucket)
+```
+see [the Boto3 docs](https://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS)
+for more information.
+
 ## S3 URLs
 
 You can get a public URL to a file on a S3 bucket as follows:

--- a/README.md
+++ b/README.md
@@ -62,19 +62,18 @@ for more information.
 ## ExtraArgs
 
 S3 objects have additional properties, beyond a traditional
-filesystem. These options can be set using the `upload_args`
-and `download_args` properties. When set on an instantiated
-filesystem, they are handed to upload and download methods,
-as appropriate, for the lifetime of the filesystem instance.
+filesystem. These options can be set using the ``upload_args``
+and ``download_args`` properties. which are handed to upload
+and download methods, as appropriate, for the lifetime of the
+filesystem instance.
 
-For example, to set the `cache-control` header of all objects
+For example, to set the ``cache-control`` header of all objects
 uploaded to a bucket:
 
 ```python
 import fs, fs.mirror
-with fs.open_fs('s3://bucket/') as bucket:
-    bucket.upload_args = {"CacheControl": "max-age=2592000", "ACL": "public-read"}
-    fs.mirror.mirror('/path/to/mirror', bucket)
+s3fs = S3FS('example', upload_args={"CacheControl": "max-age=2592000", "ACL": "public-read"})
+fs.mirror.mirror('/path/to/mirror', s3fs)
 ```
 see [the Boto3 docs](https://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS)
 for more information.

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,27 @@ filesystem to the S3 filesystem. See `Moving and
 Copying <https://docs.pyfilesystem.org/en/latest/guide.html#moving-and-copying>`__
 for more information.
 
+ExtraArgs
+---------
+
+S3 objects have additional properties, beyond a traditional
+filesystem. These options can be set using the ``upload_args``
+and ``download_args`` properties. When set on an instantiated
+filesystem, they are handed to upload and download methods,
+as appropriate, for the lifetime of the filesystem instance.
+
+For example, to set the ``cache-control`` header of all objects
+uploaded to a bucket:
+
+.. code:: python
+    import fs, fs.mirror
+    with fs.open_fs('s3://bucket/') as bucket:
+        bucket.upload_args = {"CacheControl": "max-age=2592000", "ACL": "public-read"}
+        fs.mirror.mirror('/path/to/mirror', bucket)
+
+see `the Boto3 docs <https://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS>`__
+for more information.
+
 S3 URLs
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -69,18 +69,17 @@ ExtraArgs
 
 S3 objects have additional properties, beyond a traditional
 filesystem. These options can be set using the ``upload_args``
-and ``download_args`` properties. When set on an instantiated
-filesystem, they are handed to upload and download methods,
-as appropriate, for the lifetime of the filesystem instance.
+and ``download_args`` properties. which are handed to upload
+and download methods, as appropriate, for the lifetime of the
+filesystem instance.
 
 For example, to set the ``cache-control`` header of all objects
 uploaded to a bucket:
 
 .. code:: python
     import fs, fs.mirror
-    with fs.open_fs('s3://bucket/') as bucket:
-        bucket.upload_args = {"CacheControl": "max-age=2592000", "ACL": "public-read"}
-        fs.mirror.mirror('/path/to/mirror', bucket)
+    s3fs = S3FS('example', upload_args={"CacheControl": "max-age=2592000", "ACL": "public-read"})
+    fs.mirror.mirror('/path/to/mirror', s3fs)
 
 see `the Boto3 docs <https://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS>`__
 for more information.

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,14 @@ uploaded to a bucket:
 see `the Boto3 docs <https://boto3.readthedocs.io/en/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS>`__
 for more information.
 
+``acl`` and ``cache_control`` are exposed explicitly for convenience, and can be used in URLs.
+It is important to URL-Escape the ``cache_control`` value in a URL, as it may contain special characters.
+
+.. code:: python
+    import fs, fs.mirror
+    with open fs.open_fs('s3://example?acl=public-read&cache_control=max-age%3D2592000%2Cpublic') as s3fs
+        fs.mirror.mirror('/path/to/mirror', s3fs)
+
 S3 URLs
 -------
 

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -287,6 +287,8 @@ class S3FS(FS):
         self.delimiter = delimiter
         self.strict = strict
         self._tlocal = threading.local()
+        self.download_args = None
+        self.upload_args = None
         super(S3FS, self).__init__()
 
     def __repr__(self):
@@ -540,7 +542,7 @@ class S3FS(FS):
                     s3file.raw.seek(0)
                     with s3errors(path):
                         self.client.upload_fileobj(
-                            s3file.raw, self._bucket_name, _key
+                            s3file.raw, self._bucket_name, _key, extra_args=self.upload_args
                         )
                 finally:
                     s3file.raw.close()
@@ -568,7 +570,7 @@ class S3FS(FS):
                 try:
                     with s3errors(path):
                         self.client.download_fileobj(
-                            self._bucket_name, _key, s3file.raw
+                            self._bucket_name, _key, s3file.raw, extra_args=self.download_args
                         )
                 except errors.ResourceNotFound:
                     pass
@@ -589,7 +591,7 @@ class S3FS(FS):
                     s3file.raw.seek(0, os.SEEK_SET)
                     with s3errors(path):
                         self.client.upload_fileobj(
-                            s3file.raw, self._bucket_name, _key
+                            s3file.raw, self._bucket_name, _key, extra_args=self.upload_args
                         )
             finally:
                 s3file.raw.close()
@@ -597,7 +599,7 @@ class S3FS(FS):
         s3file = S3File.factory(path, _mode, on_close=on_close)
         with s3errors(path):
             self.client.download_fileobj(
-                self._bucket_name, _key, s3file.raw
+                self._bucket_name, _key, s3file.raw, extra_args=self.download_args
             )
         s3file.seek(0, os.SEEK_SET)
         return s3file
@@ -660,7 +662,7 @@ class S3FS(FS):
         bytes_file = io.BytesIO()
         with s3errors(path):
             self.client.download_fileobj(
-                self._bucket_name, _key, bytes_file
+                self._bucket_name, _key, bytes_file, extra_args=self.download_args
             )
         return bytes_file.getvalue()
 
@@ -674,7 +676,7 @@ class S3FS(FS):
         _key = self._path_to_key(_path)
         with s3errors(path):
             self.client.download_fileobj(
-                self._bucket_name, _key, file
+                self._bucket_name, _key, file, extra_args=self.download_args
             )
 
     def exists(self, path):
@@ -758,7 +760,7 @@ class S3FS(FS):
         bytes_file = io.BytesIO(contents)
         with s3errors(path):
             self.client.upload_fileobj(
-                bytes_file, self._bucket_name, _key
+                bytes_file, self._bucket_name, _key, extra_args=self.upload_args
             )
 
     def setbinfile(self, path, file):
@@ -776,7 +778,7 @@ class S3FS(FS):
                 pass
 
         with s3errors(path):
-            self.client.upload_fileobj(file, self._bucket_name, _key)
+            self.client.upload_fileobj(file, self._bucket_name, _key, extra_args=self.upload_args)
 
     def copy(self, src_path, dst_path, overwrite=False, bucket=False):
         if not overwrite and self.exists(dst_path):

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -553,7 +553,7 @@ class S3FS(FS):
                     s3file.raw.seek(0)
                     with s3errors(path):
                         self.client.upload_fileobj(
-                            s3file.raw, self._bucket_name, _key, extra_args=self.upload_args
+                            s3file.raw, self._bucket_name, _key, ExtraArgs=self.upload_args
                         )
                 finally:
                     s3file.raw.close()
@@ -581,7 +581,7 @@ class S3FS(FS):
                 try:
                     with s3errors(path):
                         self.client.download_fileobj(
-                            self._bucket_name, _key, s3file.raw, extra_args=self.download_args
+                            self._bucket_name, _key, s3file.raw, ExtraArgs=self.download_args
                         )
                 except errors.ResourceNotFound:
                     pass
@@ -602,7 +602,7 @@ class S3FS(FS):
                     s3file.raw.seek(0, os.SEEK_SET)
                     with s3errors(path):
                         self.client.upload_fileobj(
-                            s3file.raw, self._bucket_name, _key, extra_args=self.upload_args
+                            s3file.raw, self._bucket_name, _key, ExtraArgs=self.upload_args
                         )
             finally:
                 s3file.raw.close()
@@ -610,7 +610,7 @@ class S3FS(FS):
         s3file = S3File.factory(path, _mode, on_close=on_close)
         with s3errors(path):
             self.client.download_fileobj(
-                self._bucket_name, _key, s3file.raw, extra_args=self.download_args
+                self._bucket_name, _key, s3file.raw, ExtraArgs=self.download_args
             )
         s3file.seek(0, os.SEEK_SET)
         return s3file
@@ -673,7 +673,7 @@ class S3FS(FS):
         bytes_file = io.BytesIO()
         with s3errors(path):
             self.client.download_fileobj(
-                self._bucket_name, _key, bytes_file, extra_args=self.download_args
+                self._bucket_name, _key, bytes_file, ExtraArgs=self.download_args
             )
         return bytes_file.getvalue()
 
@@ -687,7 +687,7 @@ class S3FS(FS):
         _key = self._path_to_key(_path)
         with s3errors(path):
             self.client.download_fileobj(
-                self._bucket_name, _key, file, extra_args=self.download_args
+                self._bucket_name, _key, file, ExtraArgs=self.download_args
             )
 
     def exists(self, path):
@@ -771,7 +771,7 @@ class S3FS(FS):
         bytes_file = io.BytesIO(contents)
         with s3errors(path):
             self.client.upload_fileobj(
-                bytes_file, self._bucket_name, _key, extra_args=self.upload_args
+                bytes_file, self._bucket_name, _key, ExtraArgs=self.upload_args
             )
 
     def setbinfile(self, path, file):
@@ -789,7 +789,7 @@ class S3FS(FS):
                 pass
 
         with s3errors(path):
-            self.client.upload_fileobj(file, self._bucket_name, _key, extra_args=self.upload_args)
+            self.client.upload_fileobj(file, self._bucket_name, _key, ExtraArgs=self.upload_args)
 
     def copy(self, src_path, dst_path, overwrite=False):
         if not overwrite and self.exists(dst_path):

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -269,7 +269,9 @@ class S3FS(FS):
                  endpoint_url=None,
                  region=None,
                  delimiter='/',
-                 strict=True):
+                 strict=True,
+                 upload_args=None,
+                 download_args=None):
         _creds = (aws_access_key_id, aws_secret_access_key)
         if any(_creds) and not all(_creds):
             raise ValueError(
@@ -287,8 +289,8 @@ class S3FS(FS):
         self.delimiter = delimiter
         self.strict = strict
         self._tlocal = threading.local()
-        self.download_args = None
-        self.upload_args = None
+        self.download_args = upload_args
+        self.upload_args = download_args
         super(S3FS, self).__init__()
 
     def __repr__(self):
@@ -780,7 +782,7 @@ class S3FS(FS):
         with s3errors(path):
             self.client.upload_fileobj(file, self._bucket_name, _key, extra_args=self.upload_args)
 
-    def copy(self, src_path, dst_path, overwrite=False, bucket=False):
+    def copy(self, src_path, dst_path, overwrite=False):
         if not overwrite and self.exists(dst_path):
             raise errors.DestinationExists(dst_path)
         _src_path = self.validatepath(src_path)
@@ -793,7 +795,7 @@ class S3FS(FS):
         try:
             with s3errors(src_path):
                 self.client.copy_object(
-                    Bucket=bucket or self._bucket_name,
+                    Bucket=self._bucket_name,
                     Key=_dst_key,
                     CopySource={
                         'Bucket':self._bucket_name,

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -294,8 +294,10 @@ class S3FS(FS):
         self._tlocal = threading.local()
         if cache_control or acl:
             upload_args = upload_args or {}
-            upload_args['CacheControl'] = cache_control
-            upload_args['ACL'] = acl
+            if cache_control:
+                upload_args['CacheControl'] = cache_control
+            if acl:
+                upload_args['ACL'] = acl
         self.upload_args = upload_args
         self.download_args = download_args
         super(S3FS, self).__init__()

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -778,7 +778,7 @@ class S3FS(FS):
         with s3errors(path):
             self.client.upload_fileobj(file, self._bucket_name, _key)
 
-    def copy(self, src_path, dst_path, overwrite=False):
+    def copy(self, src_path, dst_path, overwrite=False, bucket=False):
         if not overwrite and self.exists(dst_path):
             raise errors.DestinationExists(dst_path)
         _src_path = self.validatepath(src_path)
@@ -791,7 +791,7 @@ class S3FS(FS):
         try:
             with s3errors(src_path):
                 self.client.copy_object(
-                    Bucket=self._bucket_name,
+                    Bucket=bucket or self._bucket_name,
                     Key=_dst_key,
                     CopySource={
                         'Bucket':self._bucket_name,

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -293,11 +293,10 @@ class S3FS(FS):
         self.strict = strict
         self._tlocal = threading.local()
         if cache_control or acl:
-            self.upload_args = upload_args or {}
-            self.upload_args['CacheControl'] = cache_control
-            self.upload_args['ACL'] = acl
-        else:
-            self.upload_args = upload_args
+            upload_args = upload_args or {}
+            upload_args['CacheControl'] = cache_control
+            upload_args['ACL'] = acl
+        self.upload_args = upload_args
         self.download_args = download_args
         super(S3FS, self).__init__()
 

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -271,6 +271,8 @@ class S3FS(FS):
                  region=None,
                  delimiter='/',
                  strict=True,
+                 cache_control=None,
+                 acl=None,
                  upload_args=None,
                  download_args=None):
         _creds = (aws_access_key_id, aws_secret_access_key)
@@ -290,8 +292,13 @@ class S3FS(FS):
         self.delimiter = delimiter
         self.strict = strict
         self._tlocal = threading.local()
-        self.download_args = json.loads(download_args) if isinstance(download_args, str) else download_args
-        self.upload_args = json.loads(upload_args) if isinstance(upload_args, str) else upload_args
+        if cache_control or acl:
+            self.upload_args = upload_args or {}
+            self.upload_args['CacheControl'] = cache_control
+            self.upload_args['ACL'] = acl
+        else:
+            self.upload_args = upload_args
+        self.download_args = download_args
         super(S3FS, self).__init__()
 
     def __repr__(self):

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -12,6 +12,7 @@ import os
 from ssl import SSLError
 import tempfile
 import threading
+import json
 
 import boto3
 from botocore.exceptions import ClientError, EndpointConnectionError
@@ -289,8 +290,8 @@ class S3FS(FS):
         self.delimiter = delimiter
         self.strict = strict
         self._tlocal = threading.local()
-        self.download_args = upload_args
-        self.upload_args = download_args
+        self.download_args = json.loads(download_args) if isinstance(download_args, str) else download_args
+        self.upload_args = json.loads(upload_args) if isinstance(upload_args, str) else upload_args
         super(S3FS, self).__init__()
 
     def __repr__(self):

--- a/fs_s3fs/opener.py
+++ b/fs_s3fs/opener.py
@@ -33,6 +33,8 @@ class S3FSOpener(Opener):
             aws_access_key_id=parse_result.username or None,
             aws_secret_access_key=parse_result.password or None,
             endpoint_url=parse_result.params.get('endpoint_url', None),
+            acl=parse_result.params.get('acl', None),
+            cache_control=parse_result.params.get('cache_control', None),
             strict=strict
         )
         return s3fs


### PR DESCRIPTION
I didn't mean to put these two in together. Sorry.

The `ExtraArgs` change allows a simple way to set (and pass) `extra_args` to the upload and download processes.

The Bucket-to-Bucket copy just adds an input-arg to the `copy` method, allowing a user to specify a different target bucket.