### PR TITLE
issue #39: pass use_ssl, verify arguments to boto3 client constructor

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -211,6 +211,13 @@ class S3FS(FS):
         the key from standard configuration files.
     :param str aws_secret_access_key: The secret key, or ``None`` to
         read the key from standard configuration files.
+    :param bool use_ssl: Whether or not to use SSL. The default is ``True``.
+    :param bool or str verify: Whether or not to verify SSL certificates.  By
+        default SSL certificates are verified. Set to ``False`` to disable
+        verification of SSL certificates. To use a different CA cert bundle
+        than the one used by botocore, set this parameter to a string that is
+        the path to a CA cert bundle. The default is ``None``, which inherits
+        the default behavior of botocore.
     :param str endpoint_url: Alternative endpoint url (``None`` to use
         default).
     :param str aws_session_token:
@@ -275,6 +282,8 @@ class S3FS(FS):
                  aws_access_key_id=None,
                  aws_secret_access_key=None,
                  aws_session_token=None,
+                 use_ssl=True,
+                 verify=None,
                  endpoint_url=None,
                  region=None,
                  delimiter='/',
@@ -295,6 +304,8 @@ class S3FS(FS):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_session_token = aws_session_token
+        self.use_ssl = use_ssl
+        self.verify = verify
         self.endpoint_url = endpoint_url
         self.region = region
         self.delimiter = delimiter
@@ -381,6 +392,8 @@ class S3FS(FS):
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
                 aws_session_token=self.aws_session_token,
+                use_ssl=self.use_ssl,
+                verify=self.verify,
                 endpoint_url=self.endpoint_url
             )
         return self._tlocal.s3
@@ -394,6 +407,8 @@ class S3FS(FS):
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
                 aws_session_token=self.aws_session_token,
+                use_ssl=self.use_ssl,
+                verify=self.verify,
                 endpoint_url=self.endpoint_url
             )
         return self._tlocal.client

--- a/fs_s3fs/opener.py
+++ b/fs_s3fs/opener.py
@@ -22,6 +22,14 @@ class S3FSOpener(Opener):
             raise OpenerError(
                 "invalid bucket name in '{}'".format(fs_url)
             )
+        use_ssl = (
+            parse_result.params['use_ssl'] == '1'
+            if 'use_ssl' in parse_result.params
+            else True
+        )
+        verify = parse_result.params.get('verify', None)
+        if verify == '':
+            verify = False
         strict = (
             parse_result.params['strict'] == '1'
             if 'strict' in parse_result.params
@@ -32,6 +40,8 @@ class S3FSOpener(Opener):
             dir_path=dir_path or '/',
             aws_access_key_id=parse_result.username or None,
             aws_secret_access_key=parse_result.password or None,
+            use_ssl=use_ssl,
+            verify=verify,
             endpoint_url=parse_result.params.get('endpoint_url', None),
             acl=parse_result.params.get('acl', None),
             cache_control=parse_result.params.get('cache_control', None),


### PR DESCRIPTION
This commit addresses https://github.com/PyFilesystem/s3fs/issues/39

* Added `use_ssl`, `verify` arguments to the `S3FS` `__init__` method,
  which assigns instance attributes with the same names
* Pass these instance attributes to `boto3.resource` in the `s3`
  property method.
* Pass these instance attributes to `boto3.client` in the `client`
  property method.