### PR TITLE
Bug: Scandir doesn't work if the directory doesn't exist

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -693,9 +693,10 @@ class S3FS(FS):
         _s3_key = self._path_to_dir_key(_path)
         prefix_len = len(_s3_key)
 
-        info = self.getinfo(path)
-        if not info.is_dir:
-            raise errors.DirectoryExpected(path)
+        if self.strict:
+            info = self.getinfo(path)
+            if not info.is_dir:
+                raise errors.DirectoryExpected(path)
 
         paginator = self.client.get_paginator("list_objects")
         _paginate = paginator.paginate(


### PR DESCRIPTION
In some cases there is no directory exist as a key, but still there are files in that directory.
This means only if the directory is explicitly exist scandir will work in it.
The check for file was removed this means file will also be able to search any file that start with the same name. meaning shared prefix.

* change the scan to work in a key that doesn't exist only in not strict mode.