### PR TITLE
Be less strict in non-strict mode

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -492,7 +492,7 @@ class S3FS(FS):
                     if name:
                         _directory.append(name)
 
-        if not _directory:
+        if self.strict and not _directory:
             if not self.getinfo(_path).is_dir:
                 raise errors.DirectoryExpected(path)
 
@@ -503,7 +503,7 @@ class S3FS(FS):
         _path = self.validatepath(path)
         _key = self._path_to_dir_key(_path)
 
-        if not self.isdir(dirname(_path)):
+        if self.strict and not self.isdir(dirname(_path)):
             raise errors.ResourceNotFound(path)
 
         try:
@@ -543,13 +543,14 @@ class S3FS(FS):
                 finally:
                     s3file.raw.close()
 
-            try:
-                dir_path = dirname(_path)
-                if dir_path != "/":
-                    _dir_key = self._path_to_dir_key(dir_path)
-                    self._get_object(dir_path, _dir_key)
-            except errors.ResourceNotFound:
-                raise errors.ResourceNotFound(path)
+            if self.strict:
+                try:
+                    dir_path = dirname(_path)
+                    if dir_path != "/":
+                        _dir_key = self._path_to_dir_key(dir_path)
+                        self._get_object(dir_path, _dir_key)
+                except errors.ResourceNotFound:
+                    raise errors.ResourceNotFound(path)
 
             try:
                 info = self._getinfo(path)
@@ -558,7 +559,7 @@ class S3FS(FS):
             else:
                 if _mode.exclusive:
                     raise errors.FileExists(path)
-                if info.is_dir:
+                if self.strict and info.is_dir:
                     raise errors.FileExpected(path)
 
             s3file = S3File.factory(path, _mode, on_close=on_close_create)
@@ -692,9 +693,10 @@ class S3FS(FS):
         _s3_key = self._path_to_dir_key(_path)
         prefix_len = len(_s3_key)
 
-        info = self.getinfo(path)
-        if not info.is_dir:
-            raise errors.DirectoryExpected(path)
+        if self.strict:
+            info = self.getinfo(path)
+            if not info.is_dir:
+                raise errors.DirectoryExpected(path)
 
         paginator = self.client.get_paginator("list_objects")
         _paginate = paginator.paginate(


### PR DESCRIPTION
**Motivation:**

S3FS backend do not work well if bucket contains file structure without proper directory markers, even in non-strict mode. This patch skips few directory checks for `strict=False` mode (for default, strict mode old behaviour should be preserved) and makes my integration tests happy.

It does the same as #51 but in few more places.

It should fix #55, #52 and #57 in non-strict mode