### PR TITLE
remove obj.load in getinfo

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -436,7 +436,6 @@ class S3FS(FS):
                 _dir_key = self._path_to_dir_key(dir_path)
                 with s3errors(path):
                     obj = self.s3.Object(self._bucket_name, _dir_key)
-                    obj.load()
         except errors.ResourceNotFound:
             raise errors.ResourceNotFound(path)
 


### PR DESCRIPTION
fixes #70  

By removing check to `client.head_object` in `getinfo` we were able to recover expected behavior where 
 - open works when file exists
 - open fails with `fs.errors.ResourceNotFound` if file does not exist/is not accessible