### PR TITLE
Handle region in opener

### DIFF
--- a/fs_s3fs/opener.py
+++ b/fs_s3fs/opener.py
@@ -31,6 +31,7 @@ class S3FSOpener(Opener):
             aws_access_key_id=parse_result.username or None,
             aws_secret_access_key=parse_result.password or None,
             endpoint_url=parse_result.params.get("endpoint_url", None),
+            region=parse_result.params.get("region", None),
             acl=parse_result.params.get("acl", None),
             cache_control=parse_result.params.get("cache_control", None),
             strict=strict,


### PR DESCRIPTION
In order to support S3 providers such as [Scaleway](https://www.scaleway.com/en/object-storage/) it's mandatory to define a custom region.

While it's possible to build a `S3FS` instance with `region=` kwarg, by stopping using the `open_fs(url)` opener we don't leverage the generic side of pyfilesystem anymore.

