### PR TITLE
Bugfix in S3File.readinto method

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -151,7 +151,7 @@ class S3File(io.IOBase):
         return self._f.readall()
 
     def readinto(self, b):
-        return self._f.readinto()
+        return self._f.readinto(b)
 
     def write(self, b):
         if not self.__mode.writing:


### PR DESCRIPTION
A fix for issue https://github.com/PyFilesystem/s3fs/issues/76, co-authored with a colleague with whom we investigated the issue.

I also tried running tests but if I understand correctly this requires access to a bucket `fsexample`. As an improvement, I recommend using the package [`moto`](https://pypi.org/project/moto/) to run tests. The package mocks AWS services and this way allows anyone to run tests locally.