### PR TITLE
Fix for issue #68: decode key before list_objects

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -28,6 +28,7 @@ from fs.mode import Mode
 from fs.subfs import SubFS
 from fs.path import basename, dirname, forcedir, join, normpath, relpath
 from fs.time import datetime_to_epoch
+from urllib.parse import unquote
 
 
 def _make_repr(class_name, *args, **kwargs):
@@ -716,10 +717,11 @@ class S3FS(FS):
                         }
                         yield Info(info)
                 for _obj in result.get("Contents", ()):
-                    name = _obj["Key"][prefix_len:]
+                    _key = unquote(_obj["Key"])
+                    name = _key[prefix_len:]
                     if name:
                         with s3errors(path):
-                            obj = self.s3.Object(self._bucket_name, _obj["Key"])
+                            obj = self.s3.Object(self._bucket_name, _key)
                         info = self._info_from_object(obj, namespaces)
                         yield Info(info)
 


### PR DESCRIPTION
When listing directory contents the parent directory is enumerated and then metadata is obtained for each child object. The keys in the parent directory are URL encoded. These need to be decoded before obtaining the metadata because boto3 will URL encode them again, resulting in a double encoding.

This issue is easy to test by using scandir to obtain contents of a directory that contain file names with characters that will be URL encoded, such as spaces.